### PR TITLE
Board switching + Bug fixes

### DIFF
--- a/src/main/java/assets/css/custom.css
+++ b/src/main/java/assets/css/custom.css
@@ -1,5 +1,55 @@
 /* Add additional stylesheets below
 -------------------------------------------------- */
+h1 {
+    position: absolute;
+    width: 80%;
+    left: 3%;
+    top: 2%;
+    font-family: monospace;
+    font-size: 36px;
+    padding: 0px;
+    margin: 5px;
+    z-index: -2;
+}
+h2 {
+    color: red;
+    position: absolute;
+    right: 0px;
+    width: 25%;
+    text-align: center;
+    top: 42%;
+    font-family: monospace;
+
+}
+
+.small {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    background: #cccccc;
+    z-index: -1;
+}
+.big {
+    position: absolute;
+    bottom: 5%;
+    left: 5%;
+    background: white;
+    z-index: 2;
+}
+
+footer {
+    display: none;
+}
+
+hr {
+    display: none;
+}
+
+ul {
+    position: absolute;
+    right: 50px;
+    bottom: 50px;
+}
 
 .battleGrid {
     border: 1px solid black;
@@ -8,12 +58,10 @@
 
 .battleGrid tr {
     border: 1px solid black;
-    height: 30px;
 }
 
 .battleGrid td {
     border: 1px solid black;
-    width: 30px;
 }
 
 td:hover {

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -3,13 +3,16 @@ var placedShips = 0;
 var game;
 var shipType;
 var vertical;
+var gameIsOver = false;
 
-function makeGrid(table, isPlayer) {
+function makeGrid(table, isPlayer, gridSize) {
     for (i=0; i<10; i++) {
         let row = document.createElement('tr');
+        row.style.height=gridSize+"px";
         for (j=0; j<10; j++) {
             let column = document.createElement('td');
-            column.addEventListener("click", cellClick);
+            column.style.width=gridSize+"px";
+            if(gridSize == newBig()) column.addEventListener("click", cellClick);
             row.appendChild(column);
         }
         table.appendChild(row);
@@ -24,9 +27,13 @@ function markHits(board, elementId, surrenderText) {
         else if (attack.result === "HIT")
             className = "hit";
         else if (attack.result === "SUNK")
-            className = "hit"
-        else if (attack.result === "SURRENDER")
-            alert(surrenderText);
+            className = "sink"
+        else if (attack.result === "SURRENDER") {
+            className = "sink"
+            document.getElementById("player_prompt").textContent=surrenderText+"!";
+            if(!gameIsOver) alert(surrenderText);
+            gameIsOver = true;
+        }
         document.getElementById(elementId).rows[attack.location.row-1].cells[attack.location.column.charCodeAt(0) - 'A'.charCodeAt(0)].classList.add(className);
     });
 }
@@ -34,8 +41,15 @@ function markHits(board, elementId, surrenderText) {
 function redrawGrid() {
     Array.from(document.getElementById("opponent").childNodes).forEach((row) => row.remove());
     Array.from(document.getElementById("player").childNodes).forEach((row) => row.remove());
-    makeGrid(document.getElementById("opponent"), false);
-    makeGrid(document.getElementById("player"), true);
+
+    if(placedShips==3) {
+        makeGrid(document.getElementById("opponent"), false, newBig());
+        makeGrid(document.getElementById("player"), true, newSmall());
+    } else {
+        makeGrid(document.getElementById("opponent"), false, newSmall());
+        makeGrid(document.getElementById("player"), true, newBig());
+    }
+
     if (game === undefined) {
         return;
     }
@@ -68,12 +82,17 @@ function cellClick() {
     if (isSetup) {
         sendXhr("POST", "/place", {game: game, shipType: shipType, x: row, y: col, isVertical: vertical}, function(data) {
             game = data;
-            redrawGrid();
             placedShips++;
             if (placedShips == 3) {
+                document.getElementById("player_prompt").textContent="Select Your Next Attack";
+                document.getElementById("play_board").classList.toggle("small");
+                document.getElementById("opp_board").classList.toggle("small");
+                document.getElementById("play_board").classList.toggle("big");
+                document.getElementById("opp_board").classList.toggle("big");
                 isSetup = false;
                 registerCellListener((e) => {});
             }
+            redrawGrid();
         });
     } else {
         sendXhr("POST", "/attack", {game: game, x: row, y: col}, function(data) {
@@ -124,9 +143,20 @@ function place(size) {
     }
 }
 
+function newBig() {
+    return Math.floor(Math.min(document.documentElement.clientWidth, document.documentElement.clientHeight) * .85 / 10);
+}
+
+function newSmall() {
+    return Math.floor(Math.min(document.documentElement.clientWidth, document.documentElement.clientHeight) * .40 / 10);
+}
+
 function initGame() {
-    makeGrid(document.getElementById("opponent"), false);
-    makeGrid(document.getElementById("player"), true);
+    makeGrid(document.getElementById("opponent"), false, newSmall());
+    makeGrid(document.getElementById("player"), true, newBig());
+    window.addEventListener("resize", function(e) {
+            redrawGrid();
+    });
     document.getElementById("place_minesweeper").addEventListener("click", function(e) {
         shipType = "MINESWEEPER";
        registerCellListener(place(2));

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -27,9 +27,9 @@ function markHits(board, elementId, surrenderText) {
         else if (attack.result === "HIT")
             className = "hit";
         else if (attack.result === "SUNK")
-            className = "sink"
+            className = "sink";
         else if (attack.result === "SURRENDER") {
-            className = "sink"
+            className = "sink";
             document.getElementById("player_prompt").textContent=surrenderText+"!";
             if(!gameIsOver) alert(surrenderText);
             gameIsOver = true;

--- a/src/main/java/cs361/battleships/models/Game.java
+++ b/src/main/java/cs361/battleships/models/Game.java
@@ -49,12 +49,12 @@ public class Game {
 
     private char randCol() {
         //return 'A' to 'J'
-        return (char)(Math.random()*9+65);
+        return (char)(Math.random()*10+65);
     }
 
     private int randRow() {
         //return 1-10
-        return (int)(Math.random()*9+1);
+        return (int)(Math.random()*10+1);
     }
 
     private boolean randVertical() {

--- a/src/main/java/views/ApplicationController/index.ftl.html
+++ b/src/main/java/views/ApplicationController/index.ftl.html
@@ -2,13 +2,15 @@
 <@layout.myLayout "Home page">    
 
 
-<h1>The Battleship game</h1>
+<h1>BATTLESHIP: Battle Royale!</h1>
+<h2 id="player_prompt">Place your Ships</h2>
 
-<table id="opponent" class="battleGrid">
-</table>
-
-<table id="player" class="battleGrid">
-</table>
+<div id="opp_board" class="small">
+    <table id="opponent" class="battleGrid"></table>
+</div>
+<div id="play_board" class="big">
+    <table id="player" class="battleGrid"></table>
+</div>
 
 <ul>
     <li><button id="place_minesweeper">Place Minesweeper</button></li>


### PR DESCRIPTION
Board switching has been implemented (Enhancement via Issue #18). I've also included some small bug fixes from bugs (Issue #17, #20, #21) that were found during our last face-to-face meeting, as it made sense to fix them while I was working and testing this.

New Features include:
- Large board for ship placement, switching to a large board for attack selection after 3 ships are placed.
- The other board is smaller in the upper-right corner with a grey-ish background.
- Small board does not generate events upon clicking, while maintaining hover effect.
- Below the small board is an h2 element, while red text, that prompts the user for ship placement, attack placement, or if they won/lost the game. This is intended as a supplement to the alert system.

Changes:
- Title in the h1 element has been changed
- hr element and footer are temporarily set to display: none in the css
- Page elements are placed with position: absolute (sorry if this causes problems...)
- Ship placement buttons are located bottom-left, in anticipation of their removal once Issue 19 is implemented

Bug Fixes:
- Issue #20: Random Row and Column functions now correctly return values 1-10 and A-J (previously restricted to 1-9 and A-I)
- Issue #17: The final hit on a ship now correctly sets the sink class, I believe having only the final square marked as sink correctly reflects how the game works in real-life
- Issue #21: A surrender flag will now correctly tag the square with the sink class

I think this is it for now. I expect tweaking the interface and css values I've setup for this version, but I think it works pretty well for now.