### PR TITLE
implemented rotate keyboard shortcut

### DIFF
--- a/src/main/java/assets/css/custom.css
+++ b/src/main/java/assets/css/custom.css
@@ -22,6 +22,15 @@ h2 {
 
 }
 
+kbd {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 1px 8px;
+    margin: 0 3px;
+    box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
+    background-color: #f7f7f7;
+}
+
 .small {
     position: absolute;
     top: 15px;
@@ -215,3 +224,5 @@ td:hover {
 #mine2{
     background-color: green;
 }
+
+kbd()

--- a/src/main/java/assets/css/custom.css
+++ b/src/main/java/assets/css/custom.css
@@ -224,5 +224,3 @@ td:hover {
 #mine2{
     background-color: green;
 }
-
-kbd()

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -202,6 +202,15 @@ function initGame() {
     window.addEventListener("resize", function(e) {
             redrawGrid();
     });
+
+
+    // implement keypress "R" to rotate
+        document.addEventListener('keypress', function(e) {
+            if (e.which == 82 || e.which == 114) { // guard against CAPS LOCK
+              console.log(e.which);
+              document.getElementById("is_vertical").click();
+            }
+          });
     document.getElementById("place_minesweeper").addEventListener("click", function(e) {
         shipType = "MINESWEEPER";
        registerCellListener(place(2));

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -203,14 +203,13 @@ function initGame() {
             redrawGrid();
     });
 
-
     // implement keypress "R" to rotate
-        document.addEventListener('keypress', function(e) {
-            if (e.which == 82 || e.which == 114) { // guard against CAPS LOCK
-              console.log(e.which);
-              document.getElementById("is_vertical").click();
-            }
-          });
+    document.addEventListener('keypress', function(e) {
+        if (e.which == 82 || e.which == 114) { // guard against CAPS LOCK
+          console.log(e.which);
+          document.getElementById("is_vertical").click();
+        }
+      });
     document.getElementById("place_minesweeper").addEventListener("click", function(e) {
         shipType = "MINESWEEPER";
        registerCellListener(place(2));

--- a/src/main/java/views/ApplicationController/index.ftl.html
+++ b/src/main/java/views/ApplicationController/index.ftl.html
@@ -16,7 +16,7 @@
     <li><button id="place_minesweeper">Place Minesweeper</button></li>
     <li><button id="place_destroyer">Place Destroyer</button></li>
     <li><button id="place_battleship">Place Battleship</button></li>
-    <li><input type="checkbox" id="is_vertical">Vertical</input></li>
+    <li><input type="checkbox" id="is_vertical">Vertical (keyboard shortcut: <kbd>r</kbd>)</input></li>
     <li><button id="surrender">Surrender</button></li>
 </ul>
 


### PR DESCRIPTION
A shortcut for rotating ships during placement is now available. Literally, pressing R will check/uncheck the #is_vertical checkbox.