### PR TITLE
Initial implementation of Captain's Quarters

### DIFF
--- a/src/main/java/cs361/battleships/models/Ship.java
+++ b/src/main/java/cs361/battleships/models/Ship.java
@@ -12,6 +12,7 @@ public class Ship {
 	@JsonProperty private String kind;
 	@JsonProperty private int size;
 	@JsonProperty private boolean Sunk;
+	@JsonProperty private Square captainsQuarters;
 
 	public Ship() {
 		this.occupiedSquares = new ArrayList<>();
@@ -52,6 +53,18 @@ public class Ship {
 			if(vert) x++;
 			else y++;
 		}
+		createCaptainsQuarters();
+	}
+
+	public Square getCaptainsQuarters() { return this.captainsQuarters; }
+
+	public void createCaptainsQuarters(){
+		if(kind.equals("MINESWEEPER"))
+			captainsQuarters = occupiedSquares.get(0);
+		else if(kind.equals("DESTROYER"))
+			captainsQuarters = occupiedSquares.get(1);
+		else if(kind.equals("BATTLESHIP"))
+			captainsQuarters = occupiedSquares.get(2);
 	}
 
 	public int getSize(){

--- a/src/test/java/cs361/battleships/models/BoardTest.java
+++ b/src/test/java/cs361/battleships/models/BoardTest.java
@@ -105,5 +105,22 @@ public class BoardTest {
 
         System.out.println(res2.getResult());
     }
+
+    @Test
+    public void testCaptainsQuarters(){
+        Board board = new Board();
+        board.placeShip(new Ship("BATTLESHIP"), 4, 'D', true);
+        board.placeShip(new Ship("MINESWEEPER"), 1, 'B', true);
+        board.placeShip(new Ship("DESTROYER"),3,'F',false);
+
+        for(Ship ships : board.getShips()){
+            if((ships.getKind() == "BATTLESHIP") &&(ships.getCaptainsQuarters().getRow() == 6) && ships.getCaptainsQuarters().getColumn() == 'D')
+                System.out.println("Captain's Quarters on Battleship Found");
+            if((ships.getKind() == "MINESWEEPER") &&(ships.getCaptainsQuarters().getRow() == 1) && ships.getCaptainsQuarters().getColumn() == 'B')
+                System.out.println("Captain's Quarters on Minesweeper Found");
+            if(ships.getKind() == "DESTROYER" && ships.getCaptainsQuarters().getRow() == 3 && ships.getCaptainsQuarters().getColumn() == 'G')
+                System.out.println("Captain's Quarters on Destroyer Found");
+        }
+    }
 }
 


### PR DESCRIPTION
Made it so ships have a designated Captain's Quarter, marked with a Square.

The captains quarter's should be in the right spot for each ship, with the Minesweeper being the first square, the Destroyer being the second square, and Battleship being the third square.