### PR TITLE
Captain's quarter sinking implemented

### DIFF
--- a/src/main/java/assets/css/custom.css
+++ b/src/main/java/assets/css/custom.css
@@ -104,6 +104,9 @@ td:hover {
 	background-color: blue;
 }
 
+.captainsQuarter {
+    background-color: gold;
+}
 
 /* Modal Styles
 ==============================================================*/

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -93,6 +93,11 @@ function redrawGrid() {
     game.playersBoard.ships.forEach((ship) => ship.occupiedSquares.forEach((square) => {
         document.getElementById("player").rows[square.row-1].cells[square.column.charCodeAt(0) - 'A'.charCodeAt(0)].classList.add("occupied");
     }));
+    // mark captain's quarters
+    game.playersBoard.ships.forEach((ship) => {
+        document.getElementById("player").rows[ship.captainsQuarters.row-1].cells[ship.captainsQuarters.column.charCodeAt(0) - 'A'.charCodeAt(0)].classList.add("captainsQuarter");
+    });
+
     markHits(game.opponentsBoard, "opponent", "You won the game");
     markHits(game.playersBoard, "player", "You lost the game");
 }

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -55,9 +55,9 @@ function markHits(board, elementId, surrenderText) {
         let className;
         if (attack.result === "MISS")
             className = "miss";
-        else if (attack.result === "HIT")
+        if (attack.result === "HIT")
             className = "hit";
-        else if (attack.result === "SUNK"){
+        if (attack.result === "SUNK"){
             className = "sink";
         }
         else if (attack.result === "SURRENDER") {
@@ -66,7 +66,8 @@ function markHits(board, elementId, surrenderText) {
             if(!gameIsOver) alert(surrenderText);
             gameIsOver = true;
         }
-        document.getElementById(elementId).rows[attack.location.row-1].cells[attack.location.column.charCodeAt(0) - 'A'.charCodeAt(0)].classList.add(className);
+        document.getElementById(elementId).rows[attack.location.row-1].cells[attack.location.column.charCodeAt(0) - 'A'.charCodeAt(0)].className = '';
+        document.getElementById(elementId).rows[attack.location.row-1].cells[attack.location.column.charCodeAt(0) - 'A'.charCodeAt(0)].className = className;
     });
 }
 

--- a/src/main/java/cs361/battleships/models/Board.java
+++ b/src/main/java/cs361/battleships/models/Board.java
@@ -60,10 +60,11 @@ public class Board {
 			if (!isCaptainsQuarter(x,y) ) {
 				res.setResult(AttackStatus.HIT);
 			}
-			else res.setResult(AttackStatus.MISS);
+			else
+				res.setResult(AttackStatus.MISS);
 
-			if((res.getShip()).isSunk(this.getAttacks())) {
-			res.setResult(AttackStatus.SUNK);
+			if ((res.getShip()).isSunk(this.getAttacks())) {
+				res.setResult(AttackStatus.SUNK);
 				if (!this.shipsLeft()) {
 					res.setResult(AttackStatus.SURRENDER);
 				}

--- a/src/main/java/cs361/battleships/models/Board.java
+++ b/src/main/java/cs361/battleships/models/Board.java
@@ -49,16 +49,21 @@ public class Board {
 		res.setLocation(sq1);
 		//If ship is present on coordinates
 
-		if(isDuplicateAttack(sq1)) {
+		if(isDuplicateAttack(sq1) && !isCaptainsQuarter(x,y) ) {
 			res.setResult(AttackStatus.INVALID);
 			return res;
 		}
 		this.attacks.add(res);
 		if(shipPresent(x,y)){
 			res.setShip(getShip(x,y));
-			res.setResult(AttackStatus.HIT);
+
+			if (!isCaptainsQuarter(x,y) ) {
+				res.setResult(AttackStatus.HIT);
+			}
+			else res.setResult(AttackStatus.MISS);
+
 			if((res.getShip()).isSunk(this.getAttacks())) {
-				res.setResult(AttackStatus.SUNK);
+			res.setResult(AttackStatus.SUNK);
 				if (!this.shipsLeft()) {
 					res.setResult(AttackStatus.SURRENDER);
 				}
@@ -69,7 +74,7 @@ public class Board {
 			res.setResult(AttackStatus.INVALID);
 		}
 		//If no ship is on the space
-		else{
+		else {
 			res.setResult(AttackStatus.MISS);
 		}
 		return res;
@@ -80,7 +85,7 @@ public class Board {
 		//returns true if another attack at the location exists, false if not
 		for(Result attack : this.getAttacks()) {
 			if((attack.getLocation().getRow() == attackLocation.getRow()) &&
-					(attack.getLocation().getColumn() == attackLocation.getColumn())) {
+				(attack.getLocation().getColumn() == attackLocation.getColumn())) {
 				return true;
 			}
 		}
@@ -125,14 +130,29 @@ public class Board {
 		this.attacks = attacks;
 	}
 
+	// Helper function to check if a coordinate is a captain's quarter
+	public boolean isCaptainsQuarter(int x, char y) {
+		Square sq = new Square(x, y);
+		for(Ship ships : this.getShips()) {
+			if (isSquareConflict(sq, ships.getCaptainsQuarters())) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	/*
 	This function checks if a ship is present, returns true or false
 	 */
 	private boolean shipPresent(int x, char y){
 		Square sq = new Square(x, y);
 		for(Ship ships : this.getShips()){
-			for(Square squares : ships.getOccupiedSquares()){
+			for(Square squares : ships.getOccupiedSquares()) {
 				if (isSquareConflict(sq, squares)) {
+					if (isSquareConflict(sq, ships.getCaptainsQuarters())) {
+						ships.deductHealth();
+					}
 					return true;
 				}
 			}

--- a/src/main/java/cs361/battleships/models/CaptainsQuarter.java
+++ b/src/main/java/cs361/battleships/models/CaptainsQuarter.java
@@ -1,0 +1,17 @@
+package cs361.battleships.models;
+
+public class CaptainsQuarter extends Square {
+    private int health;
+
+    public int getHealth() {
+        return health;
+    }
+
+    public void setHealth(int health) {
+        this.health = health;
+    }
+
+    public void deductHealth() {
+        this.health--;
+    }
+}

--- a/src/main/java/cs361/battleships/models/Ship.java
+++ b/src/main/java/cs361/battleships/models/Ship.java
@@ -13,12 +13,14 @@ public class Ship {
 	@JsonProperty private int size;
 	@JsonProperty private boolean Sunk;
 	@JsonProperty private Square captainsQuarters;
+	@JsonProperty private int health; // HP of captain's quarter
 
 	public Ship() {
 		this.occupiedSquares = new ArrayList<>();
 		this.kind = new String();
 		this.Sunk = false;
 		this.size=0;
+		this.captainsQuarters = new CaptainsQuarter();
 	}
 
 	public Ship(String kind) {
@@ -59,22 +61,37 @@ public class Ship {
 	public Square getCaptainsQuarters() { return this.captainsQuarters; }
 
 	public void createCaptainsQuarters(){
-		if(kind.equals("MINESWEEPER"))
+		if(kind.equals("MINESWEEPER")) {
 			captainsQuarters = occupiedSquares.get(0);
-		else if(kind.equals("DESTROYER"))
+			captainsQuarters = occupiedSquares.get(0);
+			health = 1;
+		}
+		else if(kind.equals("DESTROYER")) {
 			captainsQuarters = occupiedSquares.get(1);
-		else if(kind.equals("BATTLESHIP"))
+			captainsQuarters = occupiedSquares.get(1);
+			health = 2;
+		}
+		else if(kind.equals("BATTLESHIP")) {
 			captainsQuarters = occupiedSquares.get(2);
+			captainsQuarters = occupiedSquares.get(2);
+			health = 2;
+		}
 	}
 
 	public int getSize(){
 		return this.size;
 	}
 
+	public void deductHealth() {
+		health--;
+	}
+
 	public boolean isSunk(List<Result> attacksOnBoard) {
 		//counts the number of hits on a ship. If the hit count
 		//is the same as the number of squares on the ship, we know the
 		//ship has been sunk, otherwise it has not.
+
+		/*
 		int hits = 0;
 
 		for(Square shipLocationSquare : this.getOccupiedSquares()) {
@@ -94,5 +111,13 @@ public class Ship {
 		} else {
 			return false;
 		}
+		*/
+
+		if (health == 0) {
+			Sunk = true;
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/test/java/cs361/battleships/models/AttackSpecialCases.java
+++ b/src/test/java/cs361/battleships/models/AttackSpecialCases.java
@@ -35,6 +35,7 @@ public class AttackSpecialCases {
         assertFalse(board.isDuplicateAttack(nonDuplicateLocation3));
     }
 
+    /* No longer needed since the implementation of captain's quarters
     @Test
     public void SunkenShipTest() {
         Board board = new Board();
@@ -48,4 +49,5 @@ public class AttackSpecialCases {
         Result secondAttack = board.attack(10, 'C');
         assertTrue(testShip.isSunk(board.getAttacks()));
     }
+    */
 }

--- a/src/test/java/cs361/battleships/models/BoardTest.java
+++ b/src/test/java/cs361/battleships/models/BoardTest.java
@@ -122,5 +122,32 @@ public class BoardTest {
                 System.out.println("Captain's Quarters on Destroyer Found");
         }
     }
+
+    // Test attacks on the captain's quarters
+    @Test
+    public void testAttackingCaptainsQuarters(){
+        Board board = new Board();
+        Result res;
+
+        board.placeShip(new Ship("BATTLESHIP"), 4, 'D', true);
+        board.placeShip(new Ship("MINESWEEPER"), 1, 'B', true);
+        board.placeShip(new Ship("DESTROYER"),3,'F',false);
+
+        // attack captain's quarters and print the results
+        System.out.println("Results from attacking captain's quarters:");
+
+        res = board.attack(6,'D');
+        System.out.println(res.getResult() );
+        res = board.attack(6,'D');
+        System.out.println(res.getResult() );
+
+        res = board.attack(3,'G');
+        System.out.println(res.getResult() );
+        res = board.attack(3,'G');
+        System.out.println(res.getResult() );
+
+        res = board.attack(1,'B');
+        System.out.println(res.getResult() );
+    }
 }
 


### PR DESCRIPTION
Backend:
- Ship class now have an integer that stores health points, whose amount corresponds to the armor of its captain's quarter.
- The survival of the ship is now solely determined by the state of the captain's quarter; thus, isSunk() has much simpler logic. **TO FIX**: However, the function still takes in a list of attacks as an argument; this I did not remove since it was used this way elsewhere, and my first attempt at removal resulting in the game not continuing past placing the first ship.
- If a captain's quarter survives the first hit, the attack will register as a MISS. Otherwise, the attack will SINK the ship. A test has been written to demonstrate this working correctly.

Frontend:
- The captain's quarter is colored in gold. This is hard to distinguish from the orange HIT markers. Input on color is welcome.
- A hit on the captain's quarter will be a MISS, marked in blue; however, upon the second hit, it will be a SINK, marked in red.
- **BUG**: So far, the program checks for a sinking attack by checking a ship's sunk state; therefore, the user can continue to attack squares occupied by the ship even after it's sunk (by the destruction of the captain's quarter). Attacking these will turn them red, indicating a sinking attack.