### PR TITLE
Is48

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Sprint 3 iteration of the Battleship Code
+Sprint 4 iteration of the Battleship Code
 
 Project Group 15:
 

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -9,6 +9,7 @@ var sonarPulse = 2;
 var sonarAvailable = false;
 var actionIsSonar = false;
 var isSubmerged = false;
+var spaceLaserEngaged = false;
 
 function makeGrid(table, isPlayer, gridSize) {
     for (i=0; i<10; i++) {
@@ -79,6 +80,17 @@ function markHits(board, elementId, surrenderText) {
 }
 
 function redrawGrid() {
+
+    if(spaceLaserEngaged == false && game.opponentsBoard.remainingShips < 3 && !isSetup) {
+        spaceLaserEngaged = true;
+        var laserSpan = document.createElement("span");
+        laserSpan.style.color = "red";
+        laserSpan.style.fontSize = "20px";
+        laserSpan.appendChild(document.createTextNode(" - SPACE LASER ENGAGED"));
+        document.querySelector("h1").appendChild(laserSpan);
+        alert("Warning: Space Laser has been engaged.\n\n You may now attack ANY square.");
+    }
+
     Array.from(document.getElementById("opponent").childNodes).forEach((row) => row.remove());
     Array.from(document.getElementById("player").childNodes).forEach((row) => row.remove());
 

--- a/src/main/java/cs361/battleships/models/Board.java
+++ b/src/main/java/cs361/battleships/models/Board.java
@@ -24,12 +24,9 @@ public class Board {
 	 */
 	public boolean placeShip(Ship ship, int x, char y, boolean isVertical) {
 		int shipSize = ship.getSize();
-		if(this.getShips().size()>0) {
-			if (!validShipType(ship)) return false;
-		}
-		boolean submerged = false;
-		if(ship instanceof Submarine) submerged = ((Submarine) ship).submerged;
-		if (validLocation(shipSize, x, y, isVertical, submerged)) {
+		if(this.getShips().size()>0 && !validShipType(ship)) return false;
+
+		if (validLocation(shipSize, x, y, isVertical, ship.submerged)) {
 			ship.populateSquares(x,y,isVertical);
 			this.ships.add(ship);
 			remainingShips++;

--- a/src/main/java/cs361/battleships/models/Game.java
+++ b/src/main/java/cs361/battleships/models/Game.java
@@ -23,7 +23,7 @@ public class Game {
         if (!successful) return false;
 
         Ship oppShip;
-        if(shipKind.equals("SUBMARINE"))
+        if(shipKind.equals("SUBMARINE") || shipKind.equals("submarine"))
             oppShip = new Submarine(shipKind);
         else
             oppShip = new Ship(shipKind);

--- a/src/main/java/cs361/battleships/models/Game.java
+++ b/src/main/java/cs361/battleships/models/Game.java
@@ -15,16 +15,16 @@ public class Game {
     public boolean placeShip(Ship ship, int x, char y, boolean isVertical) {
         boolean successful;
         String shipKind = ship.getKind();
-        if(shipKind.equals("SUBMARINE") || shipKind.equals("submarine")) {
-            successful = playersBoard.placeShip(new Submarine(shipKind), x, y, isVertical);
+        if(shipKind.toUpperCase().equals("SUBMARINE")) {
+            successful = playersBoard.placeShip(new Submarine(shipKind,ship.submerged), x, y, isVertical);
         }
         else
             successful = playersBoard.placeShip(new Ship(shipKind), x, y, isVertical);
         if (!successful) return false;
 
         Ship oppShip;
-        if(shipKind.equals("SUBMARINE") || shipKind.equals("submarine"))
-            oppShip = new Submarine(shipKind);
+        if(shipKind.toUpperCase().equals("SUBMARINE"))
+            oppShip = new Submarine(shipKind,ship.submerged);
         else
             oppShip = new Ship(shipKind);
         while (! (opponentsBoard.placeShip(oppShip, Board.randRow(), Board.randCol(), Board.randVertical())));

--- a/src/main/java/cs361/battleships/models/Ship.java
+++ b/src/main/java/cs361/battleships/models/Ship.java
@@ -13,6 +13,7 @@ public class Ship {
 	@JsonProperty protected Square captainsQuarters;
 	@JsonProperty protected int health; // HP of captain's quarter
 	@JsonProperty protected boolean sunk;
+	@JsonProperty protected boolean submerged;
 
 	public Ship() {
 		this.occupiedSquares = new ArrayList<>();
@@ -21,6 +22,7 @@ public class Ship {
 		this.captainsQuarters = new Square();
 		this.health=1;
 		this.sunk=false;
+		this.submerged=false;
 	}
 
 	public Ship(String kind) {

--- a/src/main/java/cs361/battleships/models/Submarine.java
+++ b/src/main/java/cs361/battleships/models/Submarine.java
@@ -10,7 +10,9 @@ public class Submarine extends Ship {
 	public Submarine(String kind) {
 		this.health = 2;
 		this.size = 5;
-		this.kind = kind;
+		if(this.kind == "SUBMARINE") submerged = true;
+		else submerged = false;
+		this.kind = kind.toUpperCase();
 	}
 
 	public void populateSquares(int x, char y, boolean vert) {

--- a/src/main/java/cs361/battleships/models/Submarine.java
+++ b/src/main/java/cs361/battleships/models/Submarine.java
@@ -10,9 +10,17 @@ public class Submarine extends Ship {
 	public Submarine(String kind) {
 		this.health = 2;
 		this.size = 5;
-		if(this.kind == "SUBMARINE") submerged = true;
-		else submerged = false;
+		this.submerged=false;
+		if(kind.equals("SUBMARINE")) this.submerged = true;
+		else this.submerged = false;
 		this.kind = kind.toUpperCase();
+	}
+
+	public Submarine(String kind, boolean submerged){
+		this.health =2;
+		this.size=5;
+		this.kind = kind.toUpperCase();
+		this.submerged = submerged;
 	}
 
 	public void populateSquares(int x, char y, boolean vert) {

--- a/src/test/java/cs361/battleships/models/BoardTest.java
+++ b/src/test/java/cs361/battleships/models/BoardTest.java
@@ -187,5 +187,24 @@ public class BoardTest {
                 System.out.println("Submarine Vertical Placement Good");
         }
     }
+
+    @Test
+    public void testAllowedDuplicateAttack(){
+        Game game = new Game();
+        //with 2 ships, duplicate attacks should be allowed, as the space laser is active
+        assertTrue(game.placeShip(new Ship("MINDSWEEPER"), 2, 'D', true));
+        assertTrue(game.placeShip(new Ship("DESTROYER"), 4, 'B', false));
+        assertTrue(game.attack(5,'D'));
+        assertTrue(game.attack(5,'D'));
+    }
+
+    @Test
+    //Place a submerged submarine directly under another ship
+    public void testSubmergedSubmarinePlacement(){
+        Board board = new Board();
+        board.placeShip(new Ship("BATTLESHIP"), 5, 'B', false);
+        assertTrue(board.placeShip(new Submarine("SUBMARINE", true),5,'B', false));
+
+    }
 }
 

--- a/src/test/java/cs361/battleships/models/GameTest.java
+++ b/src/test/java/cs361/battleships/models/GameTest.java
@@ -1,0 +1,31 @@
+package cs361.battleships.models;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class GameTest {
+
+    @Test
+    public void testFullGameSetup(){
+        Game game = new Game();
+
+        //4 ships placed
+        assertTrue(game.placeShip(new Ship("MINDSWEEPER"), 2, 'D', true));
+        assertTrue(game.placeShip(new Ship("DESTROYER"), 4, 'B', false));
+        assertTrue(game.placeShip(new Ship("BATTLESHIP"), 5, 'C', false));
+        assertTrue(game.placeShip(new Ship("submarine"), 7, 'E', false));
+
+        //attack the 4 corners
+        assertTrue(game.attack(1,'A'));
+        assertTrue(game.attack(10,'A'));
+        assertTrue(game.attack(10, 'J'));
+        assertTrue(game.attack(1,'J'));
+
+
+
+    }
+}

--- a/src/test/java/cs361/battleships/models/SquareTest.java
+++ b/src/test/java/cs361/battleships/models/SquareTest.java
@@ -1,0 +1,37 @@
+package cs361.battleships.models;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class SquareTest {
+
+    @Test
+    public void testSquareRows(){
+        Square tester = new Square();
+        for(int i = 0; i<=10; i++) {
+            tester.setRow(i);
+            assertTrue(tester.getRow() == i);
+        }
+    }
+
+    @Test
+    public void testSquareCols(){
+        Square tester = new Square();
+        for(int i = 63; i<=74; i++) {
+            tester.setColumn((char)i);
+            assertTrue(tester.getColumn() == (char)i);
+        }
+    }
+
+    @Test
+    public void testSquareInit(){
+        Square tester = new Square(5,'e');
+        assertTrue(tester.getRow()==5);
+        assertTrue(tester.getColumn()=='e');
+    }
+
+}

--- a/src/test/java/cs361/battleships/models/SubmarineTest.java
+++ b/src/test/java/cs361/battleships/models/SubmarineTest.java
@@ -1,0 +1,33 @@
+package cs361.battleships.models;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class SubmarineTest {
+
+    //Testing to make sure the kind is converted to uppercase and submerged is initialized to true, this is a unique init for this extended class
+    @Test
+    public void testSubmarineSubmergedInit(){
+        Submarine tester = new Submarine("submarine",true);
+        String answer = "SUBMARINE";
+        assertTrue(tester.getKind().equals("SUBMARINE"));
+        assertTrue(tester.submerged);
+        //this should convert the kind to uppercase and test the submerged flag to false.
+        //this is how the submerged flag is passed through the front end
+        Submarine testerB = new Submarine("submarine");
+        assertTrue(testerB.getKind().equals("SUBMARINE"));
+        assertFalse(testerB.submerged);
+    }
+
+    //This class is unique in that it has 5 occupied squares, I want to make sure that the loop for setting those squares generates all 5
+    @Test
+    public void testSquaresCount(){
+        Submarine tester = new Submarine("SUBMARINE");
+        tester.populateSquares(5,'E',true);
+        assertTrue(tester.getOccupiedSquares().size() == 5);
+    }
+}


### PR DESCRIPTION
Alright, Let's see if I can remember everything:

### Submarine Placement Fixes
- Submarines should be able to be placed properly, respecting boundary edges and other ships.
- When a submarine is placed as submerged (shown by green outline and a transparency effect), it can be placed under any ship.

### Attacking Adjustments
- When attacking with more than 2 opponent ships remaining, the player (and opponent) cannot attack submerged submarines.
- Surfaced ships above submarines WILL take damage during this phase.
- Duplicate attacks are only allowed on surfaced captains quarters at this more

### Space Laser
- When 2 ships remain, the user is given an alert warning that the space laser is active, and all duplicate attacks are allowed.
- I added a space-laser notifier next to the title, it seems to fit in well there.
- The space laser will attack all ships on a square, on the surface, submerged, or both.
- The opponent has this same ability after eliminating 2 of the player's ships.


### Known Issues:
- After the opponent has their space laser, they are extremely easy to beat because their random attacks can then attack anywhere.
- With multiple attacks on some squares, the displayed result can be inconsistent. Misses can override ship locations when the user re-clicks some squares. I see this as a non-priority currently.
- The game is easy. Way easier than after Sprint 3. Oh well.

Primarily, This resolves Issue #48.
Additionally, it provides bug fixes from PR #54 (specially lingering issues from #50 and #53 concerning the Submarine User Stories).